### PR TITLE
feat: Implement Bitbucket AddIssueAsync method

### DIFF
--- a/Infrastructure.Tests/Services/BitbucketServiceTests.cs
+++ b/Infrastructure.Tests/Services/BitbucketServiceTests.cs
@@ -1,0 +1,303 @@
+﻿using Application.Enums;
+using Application.Models;
+using Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Infrastructure.Tests.Services
+{
+    public class BitbucketServiceTests
+    {
+        private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+        private readonly Mock<IConfiguration> _mockConfiguration;
+        private readonly HttpClient _httpClient;
+        private readonly BitbucketService _bitbucketService;
+        private readonly RepositoryInfo _validRepoInfo;
+        private const string ValidBitbucketUsername = "test@example.com";
+        private const string ValidBitbucketAppPassword = "fake-app-password";
+        private const string BitbucketUsernameConfigKey = "GitProviders:Bitbucket:Username";
+        private const string BitbucketAppPasswordConfigKey = "GitProviders:Bitbucket:AppPassword";
+
+        public BitbucketServiceTests()
+        {
+            _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            _mockConfiguration = new Mock<IConfiguration>();
+
+            _httpClient = new HttpClient(_mockHttpMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://api.bitbucket.org/2.0/")
+            };
+
+            _bitbucketService = new BitbucketService(_httpClient, _mockConfiguration.Object);
+
+            _validRepoInfo = new RepositoryInfo
+            {
+                Provider = ProviderType.Bitbucket,
+                Owner = "test-workspace",
+                RepositoryName = "test-slug"
+            };
+        }
+
+        #region Helper
+
+        private void SetupMockBitbucketCredentials(string? username, string? appPassword)
+        {
+            _mockConfiguration.Setup(c => c[BitbucketUsernameConfigKey]).Returns(username);
+            _mockConfiguration.Setup(c => c[BitbucketAppPasswordConfigKey]).Returns(appPassword);
+        }
+
+        // HttpMessageHandler
+        private void SetupMockHttpResponseForBitbucket(HttpStatusCode statusCode, string jsonResponseContent, out string? capturedContent)
+        {
+            string? content = null; 
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) =>
+                {
+                    if (req.Content != null)
+                    {
+                        content = req.Content.ReadAsStringAsync(ct).GetAwaiter().GetResult();
+                    }
+                })
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(jsonResponseContent)
+                });
+            capturedContent = content;
+        }
+
+        // HttpMessageHandler web errors
+        private void SetupMockHttpExceptionForBitbucket(Exception exception)
+        {
+            _mockHttpMessageHandler.Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                   "SendAsync",
+                   ItExpr.IsAny<HttpRequestMessage>(),
+                   ItExpr.IsAny<CancellationToken>()
+               )
+               .ThrowsAsync(exception);
+        }
+
+        #endregion
+
+        #region Tests AddIssueAsync
+
+        [Fact]
+        public async Task AddIssueAsync_Success_SendsCorrectPayloadAndAuth_ReturnsMappedIssue()
+        {
+            // Arrange
+            var request = new CreateIssueRequest { Title = "Bitbucket Test", Description = "BB Desc" };
+            var expectedBitbucketId = 54321;
+            var expectedState = "new";
+            var expectedUrl = "https://bitbucket.org/test-workspace/test-slug/issues/54321";
+
+            SetupMockBitbucketCredentials(ValidBitbucketUsername, ValidBitbucketAppPassword);
+
+            var fakeJsonResponse = $@"{{
+                ""id"": {expectedBitbucketId},
+                ""title"": ""{request.Title}"",
+                ""content"": {{ ""raw"": ""{request.Description}"", ""markup"": ""markdown"", ""html"": ""<p>BB Desc</p>"" }},
+                ""state"": ""{expectedState}"",
+                ""links"": {{ ""html"": {{ ""href"": ""{expectedUrl}"" }} }}
+            }}";
+
+            var expectedAuthParam = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{ValidBitbucketUsername}:{ValidBitbucketAppPassword}"));
+
+            string? capturedContent = null;
+            _mockHttpMessageHandler.Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+               .Callback<HttpRequestMessage, CancellationToken>((req, ct) => { if (req.Content != null) { capturedContent = req.Content.ReadAsStringAsync(ct).GetAwaiter().GetResult(); } })
+               .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Created, Content = new StringContent(fakeJsonResponse) });
+
+
+            // Act
+            var result = await _bitbucketService.AddIssueAsync(_validRepoInfo, request);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedBitbucketId.ToString(), result.Id);
+            Assert.Equal(expectedBitbucketId.ToString(), result.DisplayId);
+            Assert.Equal(request.Title, result.Title);
+            Assert.Equal(request.Description, result.Description);
+            Assert.Equal(expectedState, result.State);
+            Assert.Equal(expectedUrl, result.Url);
+            Assert.Equal(ProviderType.Bitbucket, result.Provider);
+
+            _mockHttpMessageHandler.Protected().Verify(
+               "SendAsync",
+               Times.Exactly(1),
+               ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Method == HttpMethod.Post
+                && req.RequestUri.AbsoluteUri == $"https://api.bitbucket.org/2.0/repositories/{_validRepoInfo.Owner}/{_validRepoInfo.RepositoryName}/issues"
+                && req.Headers.Authorization != null
+                && req.Headers.Authorization.Scheme == "Basic"
+                && req.Headers.Authorization.Parameter == expectedAuthParam
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+
+            Assert.NotNull(capturedContent);
+            using (var doc = JsonDocument.Parse(capturedContent))
+            {
+                Assert.True(doc.RootElement.TryGetProperty("title", out var titleProp) && titleProp.GetString() == request.Title);
+                Assert.True(doc.RootElement.TryGetProperty("content", out var contentProp) && contentProp.TryGetProperty("raw", out var rawProp) && rawProp.GetString() == request.Description);
+                Assert.Equal(2, doc.RootElement.EnumerateObject().Count());
+            }
+        }
+
+        [Fact]
+        public async Task AddIssueAsync_Success_NoDescription_SendsCorrectPayload()
+        {
+            // Arrange
+            var request = new CreateIssueRequest { Title = "BB No Desc", Description = null };
+            SetupMockBitbucketCredentials(ValidBitbucketUsername, ValidBitbucketAppPassword);
+            var fakeJsonResponse = $@"{{ ""id"": 54322, ""title"": ""{request.Title}"", ""content"": null, ""state"": ""new"", ""links"": {{ ""html"": {{ ""href"": ""url"" }} }} }}";
+            var expectedAuthParam = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{ValidBitbucketUsername}:{ValidBitbucketAppPassword}"));
+            string? capturedContent = null;
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) =>
+                {
+                    if (req.Content != null)
+                    {
+                        capturedContent = req.Content.ReadAsStringAsync(ct).GetAwaiter().GetResult();
+                    }
+                })
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Created,
+                    Content = new StringContent(fakeJsonResponse)
+                });
+
+
+            // Act
+            await _bitbucketService.AddIssueAsync(_validRepoInfo, request);
+
+            // Assert
+            _mockHttpMessageHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                 ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Method == HttpMethod.Post
+                    && req.RequestUri.AbsoluteUri == $"https://api.bitbucket.org/2.0/repositories/{_validRepoInfo.Owner}/{_validRepoInfo.RepositoryName}/issues"
+                    && req.Headers.Authorization != null && req.Headers.Authorization.Parameter == expectedAuthParam 
+                 ),
+                ItExpr.IsAny<CancellationToken>());
+
+            Assert.NotNull(capturedContent);
+            using (var doc = JsonDocument.Parse(capturedContent))
+            {
+                Assert.True(doc.RootElement.TryGetProperty("title", out var titleProp) && titleProp.GetString() == request.Title);
+                Assert.False(doc.RootElement.TryGetProperty("content", out _)); 
+                Assert.Equal(1, doc.RootElement.EnumerateObject().Count());
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)] 
+        [InlineData(HttpStatusCode.NotFound)]
+        [InlineData(HttpStatusCode.InternalServerError)]
+        public async Task AddIssueAsync_ApiReturnsError_ThrowsHttpRequestException(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var request = new CreateIssueRequest { Title = "Test Error" };
+            var errorJson = @"{""type"": ""error"", ""error"": {""message"": ""Something went wrong""}}";
+            SetupMockBitbucketCredentials(ValidBitbucketUsername, ValidBitbucketAppPassword);
+            string? capturedContent; 
+            SetupMockHttpResponseForBitbucket(statusCode, errorJson, out capturedContent);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<HttpRequestException>(
+                () => _bitbucketService.AddIssueAsync(_validRepoInfo, request)
+            );
+            Assert.Equal(statusCode, exception.StatusCode);
+            if (statusCode == HttpStatusCode.Unauthorized)
+                Assert.Contains("authentication failed", exception.Message);
+            else if (statusCode == HttpStatusCode.NotFound)
+                Assert.Contains("repository", exception.Message);
+            Assert.Contains(errorJson, exception.Message);
+        }
+
+        [Fact]
+        public async Task AddIssueAsync_InvalidJsonResponse_ThrowsJsonException()
+        {
+            // Arrange
+            var request = new CreateIssueRequest { Title = "Test Invalid Json" };
+            var invalidJsonResponse = @"{""id"": 123"; 
+            SetupMockBitbucketCredentials(ValidBitbucketUsername, ValidBitbucketAppPassword);
+            string? capturedContent;
+            SetupMockHttpResponseForBitbucket(HttpStatusCode.Created, invalidJsonResponse, out capturedContent);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<JsonException>(
+                () => _bitbucketService.AddIssueAsync(_validRepoInfo, request)
+            );
+        }
+
+        [Fact]
+        public async Task AddIssueAsync_MissingCredentials_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var request = new CreateIssueRequest { Title = "Test Missing Creds" };
+            SetupMockBitbucketCredentials(null, ValidBitbucketAppPassword);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _bitbucketService.AddIssueAsync(_validRepoInfo, request)
+            );
+            Assert.Contains("username or App Password is missing", exception.Message);
+        }
+
+        [Fact]
+        public async Task AddIssueAsync_NullTitle_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var request = new CreateIssueRequest { Title = null };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => _bitbucketService.AddIssueAsync(_validRepoInfo, request)
+            );
+        }
+
+        [Fact]
+        public async Task AddIssueAsync_NetworkError_ThrowsHttpRequestException()
+        {
+            // Arrange
+            var request = new CreateIssueRequest { Title = "Test Network Error" };
+            SetupMockBitbucketCredentials(ValidBitbucketUsername, ValidBitbucketAppPassword);
+            SetupMockHttpExceptionForBitbucket(new HttpRequestException("Simulated network error"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<HttpRequestException>(
+                 () => _bitbucketService.AddIssueAsync(_validRepoInfo, request)
+            );
+        }
+
+        #endregion
+
+    }
+}

--- a/Infrastructure/Services/BitbucketService.cs
+++ b/Infrastructure/Services/BitbucketService.cs
@@ -179,6 +179,6 @@ namespace Infrastructure.Services
             public string? Href { get; set; }
         }
 
-
+        #endregion
     }
 }

--- a/Infrastructure/Services/BitbucketService.cs
+++ b/Infrastructure/Services/BitbucketService.cs
@@ -1,0 +1,184 @@
+﻿using Application.Enums;
+using Application.Interfaces;
+using Application.Models;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Infrastructure.Services
+{
+    /// <summary>
+    /// Service for interacting with the Bitbucket Issues API (v2.0).
+    /// Implements the IGitIssueService interface for Bitbucket specific operations.
+    /// </summary>
+    public class BitbucketService : IGitIssueService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _configuration;
+        private const string BitbucketUsernameConfigKey = "GitProviders:Bitbucket:Username";
+        private const string BitbucketAppPasswordConfigKey = "GitProviders:Bitbucket:AppPassword";
+        private const string BitbucketAcceptHeader = "application/json";
+
+        public BitbucketService(HttpClient httpClient, IConfiguration configuration)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+
+            if (_httpClient.DefaultRequestHeaders.Accept.All(h => h.MediaType != BitbucketAcceptHeader))
+            {
+                _httpClient.DefaultRequestHeaders.Accept.Add(
+                   new MediaTypeWithQualityHeaderValue(BitbucketAcceptHeader));
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<IssueDetailsResponse> AddIssueAsync(
+            RepositoryInfo repoInfo,
+            CreateIssueRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(repoInfo);
+            ArgumentNullException.ThrowIfNull(request);
+            ArgumentException.ThrowIfNullOrWhiteSpace(request.Title);
+
+            if (repoInfo.Provider != ProviderType.Bitbucket)
+            {
+                throw new ArgumentException("RepositoryInfo must specify Bitbucket provider.", nameof(repoInfo));
+            }
+
+            var username = _configuration[BitbucketUsernameConfigKey];
+            var appPassword = _configuration[BitbucketAppPasswordConfigKey];
+
+            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(appPassword))
+            {
+                throw new InvalidOperationException($"Bitbucket username or App Password is missing. Configure them using keys: '{BitbucketUsernameConfigKey}', '{BitbucketAppPasswordConfigKey}'.");
+            }
+
+            // /repositories/{workspace}/{repo_slug}/issues
+            var url = $"repositories/{repoInfo.Owner}/{repoInfo.RepositoryName}/issues";
+
+            var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{appPassword}"));
+            var authHeader = new AuthenticationHeaderValue("Basic", credentials);
+
+            object payload;
+            if (request.Description != null)
+            {
+                payload = new { title = request.Title, content = new { raw = request.Description } };
+            }
+            else
+            {
+                payload = new { title = request.Title };
+            }
+
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
+            requestMessage.Headers.Authorization = authHeader;
+            requestMessage.Content = JsonContent.Create(payload, options: new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            });
+
+            HttpResponseMessage response = await _httpClient.SendAsync(requestMessage, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                try
+                {
+                    var serializerOptions = new JsonSerializerOptions
+                    {
+                        PropertyNameCaseInsensitive = true
+                    };
+
+                    BitbucketIssueApiResponse bitbucketIssue = await response.Content.ReadFromJsonAsync<BitbucketIssueApiResponse>(
+                                                                serializerOptions,
+                                                                cancellationToken)
+                                                             ?? throw new InvalidOperationException("Bitbucket API returned null content unexpectedly.");
+                    return MapToIssueDetailsResponse(bitbucketIssue, repoInfo);
+                }
+                catch (JsonException jsonEx)
+                {
+                    throw;
+                }
+            }
+            else
+            {
+                string errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    throw new HttpRequestException($"Bitbucket API authentication failed. Check username/App Password. Status code: {response.StatusCode}. Response: {errorContent}", null, response.StatusCode);
+                }
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    throw new HttpRequestException($"Bitbucket repository '{repoInfo.Owner}/{repoInfo.RepositoryName}' not found. Status code: {response.StatusCode}. Response: {errorContent}", null, response.StatusCode);
+                }
+                throw new HttpRequestException(
+                    $"Bitbucket API request failed with status code {response.StatusCode}. URL: {url}. Response: {errorContent}",
+                    null,
+                    response.StatusCode);
+            }
+        }
+
+        public Task<IssueDetailsResponse> UpdateIssueAsync(RepositoryInfo repoInfo, string issueId, UpdateIssueRequest request, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IssueDetailsResponse> CloseIssueAsync(RepositoryInfo repoInfo, string issueId, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        #region private helper methods
+
+        private IssueDetailsResponse MapToIssueDetailsResponse(BitbucketIssueApiResponse bbIssue, RepositoryInfo repoInfo)
+        {
+            return new IssueDetailsResponse
+            {
+                Id = bbIssue.Id.ToString(),
+                DisplayId = bbIssue.Id.ToString(),
+                Title = bbIssue.Title ?? string.Empty,
+                Description = bbIssue.Content?.Raw,
+                State = bbIssue.State ?? "unknown",
+                Url = bbIssue.Links?.Html?.Href,
+                Provider = ProviderType.Bitbucket,
+                RepositoryName = repoInfo.RepositoryName,
+                Owner = repoInfo.Owner
+            };
+        }
+
+        private class BitbucketIssueApiResponse
+        {
+            public int Id { get; set; }
+            public string? Title { get; set; }
+            public BitbucketContent? Content { get; set; }
+            public string? State { get; set; }
+            public BitbucketLinks? Links { get; set; }
+        }
+
+        private class BitbucketContent
+        {
+            public string? Raw { get; set; }
+            public string? Markup { get; set; }
+            public string? Html { get; set; }
+        }
+
+        private class BitbucketLinks
+        {
+            public BitbucketLink? Html { get; set; }
+        }
+
+        private class BitbucketLink
+        {
+            public string? Href { get; set; }
+        }
+
+
+    }
+}


### PR DESCRIPTION
Implements the AddIssueAsync method for creating issues via Bitbucket API v2.0.
Add unit tests for Bitbucket AddIssueAsync

Closes #6
Refs #15